### PR TITLE
doc: remove the few tabs left over.

### DIFF
--- a/doc/xdg_open.txt
+++ b/doc/xdg_open.txt
@@ -63,10 +63,10 @@ Don't map any keys when loading the plugin.
 MAPPINGS                                                   *xdg_open-mappings*
 
                            *gx*
-gx			Try to open the file under the cursor.
+gx                                 Try to open the file under the cursor.
 
                            *v_gx*
-{Visual}gx			Try to open the current visual selection.
+{Visual}gx                         Try to open the current visual selection.
 
 ==============================================================================
 FUNCTIONS                                                 *xdg_open-functions*


### PR DESCRIPTION
The help file has 'expandtab' in the modeline and almost all the
aligning is done with spaces so the 3 tabs left over are inconsistent
and don't align very well.