### PR TITLE
plugin: abort on error for s:get_text

### DIFF
--- a/plugin/xdg_open.vim
+++ b/plugin/xdg_open.vim
@@ -72,7 +72,7 @@ endfun
 
 
 " Get text to open
-fun s:get_text(source)
+fun s:get_text(source) abort
 	" Word under cursor
 	if a:source is 0
 		let l:text = expand(g:xdg_open_match)


### PR DESCRIPTION
Change the function definition for get_text to have the abort
keyword. This is general good practice.